### PR TITLE
Hide cursor with controls in fullscreen

### DIFF
--- a/Sources/Shared/AutoHide.swift
+++ b/Sources/Shared/AutoHide.swift
@@ -6,3 +6,7 @@ import Foundation
 func shouldHideControls(now: TimeInterval, lastActivity: TimeInterval, interval: TimeInterval) -> Bool {
     (now - lastActivity) > interval
 }
+
+func shouldHideCursor(controlsVisible: Bool, isFullScreen: Bool) -> Bool {
+    !controlsVisible && isFullScreen
+}

--- a/Sources/macOS/Views/PlayerContainerView.swift
+++ b/Sources/macOS/Views/PlayerContainerView.swift
@@ -57,6 +57,16 @@ struct PlayerContainerView: View {
                 .allowsHitTesting(false)
         }
         .onAppear { NSApp.keyWindow?.acceptsMouseMovedEvents = true }
+        .onDisappear { NSCursor.setHiddenUntilMouseMoves(false) }
+        .onChange(of: controlsVisible) { _, visible in
+            updateCursorVisibility(controlsVisible: visible)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didEnterFullScreenNotification)) { notification in
+            updateCursorVisibility(for: notification)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification)) { notification in
+            updateCursorVisibility(for: notification)
+        }
         .onReceive(tick) { _ in
             if shouldHideControls(now: Date().timeIntervalSinceReferenceDate,
                                   lastActivity: lastActivity.timeIntervalSinceReferenceDate,
@@ -70,6 +80,18 @@ struct PlayerContainerView: View {
     private func bumpActivity() {
         lastActivity = Date()
         if !controlsVisible { withAnimation { controlsVisible = true } }
+    }
+
+    private func updateCursorVisibility(for notification: Notification) {
+        guard let window = notification.object as? NSWindow, window.isKeyWindow else { return }
+        updateCursorVisibility(controlsVisible: controlsVisible, window: window)
+    }
+
+    private func updateCursorVisibility(controlsVisible: Bool, window: NSWindow? = NSApp.keyWindow) {
+        let isFullScreen = window?.styleMask.contains(.fullScreen) == true
+        NSCursor.setHiddenUntilMouseMoves(
+            shouldHideCursor(controlsVisible: controlsVisible, isFullScreen: isFullScreen)
+        )
     }
 
     private func handleKey(_ event: NSEvent) -> Bool {

--- a/Tests/AetherPlayerTests/AutoHideTests.swift
+++ b/Tests/AetherPlayerTests/AutoHideTests.swift
@@ -11,4 +11,13 @@ final class AutoHideTests: XCTestCase {
     func testBoundaryStaysVisible() {
         XCTAssertFalse(shouldHideControls(now: 100, lastActivity: 97, interval: 3))
     }
+    func testHidesCursorWithControlsInFullScreen() {
+        XCTAssertTrue(shouldHideCursor(controlsVisible: false, isFullScreen: true))
+    }
+    func testKeepsCursorVisibleWithControls() {
+        XCTAssertFalse(shouldHideCursor(controlsVisible: true, isFullScreen: true))
+    }
+    func testKeepsCursorVisibleOutsideFullScreen() {
+        XCTAssertFalse(shouldHideCursor(controlsVisible: false, isFullScreen: false))
+    }
 }


### PR DESCRIPTION
Re #4.

- Hides the cursor when playback controls auto-hide in fullscreen
- Restores it on mouse movement and when leaving fullscreen
- Keeps the cursor visible in windowed mode
- Adds tests for the cursor visibility rules

Verification:
- Built and exercised fullscreen playback on macOS
- `xcodebuild` test passed: 71 XCTest and 23 Swift Testing cases